### PR TITLE
Local registry for staging deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem "decidim-superspaces", git: "https://github.com/Platoniq/decidim-superspace"
 gem "decidim-templates", DECIDIM_VERSION
 gem "decidim-term_customizer", git: "https://github.com/Platoniq/decidim-module-term_customizer", branch: "main"
 
+gem "appsignal"
+
 gem "puma", ">= 6.3.1"
 
 gem "wicked_pdf", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,9 @@ GEM
       activesupport (>= 6.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    appsignal (4.8.1)
+      logger
+      rack (>= 2.0.0)
     ast (2.4.3)
     aws-eventstream (1.3.2)
     aws-partitions (1.1076.0)
@@ -126,7 +129,7 @@ GEM
       smart_properties
     bigdecimal (3.3.1)
     bindex (0.8.1)
-    bootsnap (1.10.3)
+    bootsnap (1.20.1)
       msgpack (~> 1.2)
     brakeman (6.1.0)
     browser (6.2.0)
@@ -550,7 +553,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.26.0)
-    msgpack (1.4.5)
+    msgpack (1.8.0)
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
     net-http (0.6.0)
@@ -888,6 +891,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  appsignal
   aws-sdk-s3 (= 1.160.0)
   bootsnap (~> 1.3)
   brakeman (~> 6.1)

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -22,7 +22,7 @@ proxy:
 # Credentials for your image host.
 registry:
   # Specify the registry server, if you're not using Docker Hub
-  server: registry.platoniq.net
+  server: localhost:5555
   username: goteo
   # Always use an access token rather than real password (pulled from .kamal/secrets).
   password:


### PR DESCRIPTION
This saves us the hosting cost of a registry server, or exposing the image on docker hub (On staging, for now).
Further reading: [https://kamal-deploy.org/docs/configuration/docker-registry](https://kamal-deploy.org/docs/configuration/docker-registry)