### PR TITLE
Switch decidim-term_customizer to the openpoke maintained fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "decidim-design", DECIDIM_VERSION
 gem "decidim-initiatives", DECIDIM_VERSION
 gem "decidim-superspaces", git: "https://github.com/Platoniq/decidim-superspace", branch: "main"
 gem "decidim-templates", DECIDIM_VERSION
-gem "decidim-term_customizer", git: "https://github.com/Platoniq/decidim-module-term_customizer", branch: "main"
+gem "decidim-term_customizer", github: "openpoke/decidim-module-term_customizer", branch: "release/0.30-stable"
 
 gem "appsignal"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/Platoniq/decidim-module-term_customizer
-  revision: 3a792afb1edd78421b63964f3d1eea6e091f759f
-  branch: main
-  specs:
-    decidim-term_customizer (0.30)
-      decidim-admin (~> 0.30.0)
-      decidim-core (~> 0.30.0)
-
-GIT
   remote: https://github.com/Platoniq/decidim-superspace
   revision: afda2ab25803d1406214e09c3a1b14466854c360
   branch: main
@@ -16,6 +7,15 @@ GIT
       decidim-conferences (>= 0.30.0, < 0.31)
       decidim-core (>= 0.30.0, < 0.31)
       deface (~> 1.9)
+
+GIT
+  remote: https://github.com/openpoke/decidim-module-term_customizer.git
+  revision: 00d55ec218e84e5bced560b3b4253f06c9e8104b
+  branch: release/0.30-stable
+  specs:
+    decidim-term_customizer (0.30)
+      decidim-admin (~> 0.30.0)
+      decidim-core (~> 0.30.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
## Summary
- Was pinned to Platoniq's own fork of `decidim-term_customizer` (branch `main`), which has fallen behind.
- `openpoke/decidim-module-term_customizer` actively maintains a `release/0.30-stable` branch matching this app's Decidim 0.30.9, so we can depend on their upkeep instead of patching our own fork.

## Verification
- `bundle install` resolves cleanly against the new source.
- `bin/rails decidim:upgrade` + `bin/rails db:migrate` against a fresh local database produce no new/changed migrations (same Decidim compat range, just a different upstream).

## Test plan
- [ ] `bundle install`
- [ ] `bin/rails decidim:upgrade`
- [ ] `bin/rails db:migrate`
- [ ] Smoke-test term customizer admin screens