### PR TITLE
Run background jobs on Sidekiq

### DIFF
--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -6,10 +6,12 @@ image: platoniq/decidim-soiltribes
 servers:
   web:
     - 116.203.142.173
-  # job:
-  #   hosts:
-  #     - 192.168.0.1
-  #   cmd: bin/jobs
+  workers:
+    hosts:
+      - 116.203.142.173
+    cmd: bundle exec sidekiq
+    options:
+      no-healthcheck: true
 deploy_timeout: 120
 # Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
 # Remove this section when using multiple web servers and ensure you terminate SSL at your load balancer.
@@ -108,35 +110,3 @@ accessories:
     port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
-  sidekiq:
-    image: platoniq/decidim-soiltribes
-    host: 116.203.142.173
-    cmd: bundle exec sidekiq
-    env:
-      clear:
-        RAILS_SERVE_STATIC_FILES: true
-        DECIDIM_APPLICATION_NAME: "Soiltribes"
-        DECIDIM_MAILER_SENDER: no-reply@platoniq.net
-        DECIDIM_DEFAULT_LOCALE: "ca"
-        STORAGE_PROVIDER: s3
-        DECIDIM_FORCE_SSL: false
-        RAILS_ENV: production
-        DECIDIM_ENABLE_HTML_HEADER_SNIPPETS: true
-        DECIDIM_CACHE_EXPIRATION_TIME: "10"
-      secret:
-        - RAILS_MASTER_KEY
-        - SECRET_KEY_BASE
-        - DATABASE_URL
-        - SMTP_ADDRESS
-        - SMTP_USERNAME
-        - SMTP_PASSWORD
-        - SMTP_DOMAIN
-        - SMTP_STARTTLS_AUTO
-        - POSTGRES_PASSWORD
-        - POSTGRES_USER
-        - POSTGRES_DB
-        - AWS_ACCESS_KEY_ID
-        - AWS_SECRET_ACCESS_KEY
-        - AWS_REGION
-        - AWS_BUCKET
-        - REDIS_URL

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -6,10 +6,12 @@ image: platoniq/decidim-soiltribes
 servers:
   web:
     - 188.34.186.145
-  # job:
-  #   hosts:
-  #     - 192.168.0.1
-  #   cmd: bin/jobs
+  workers:
+    hosts:
+      - 188.34.186.145
+    cmd: bundle exec sidekiq
+    options:
+      no-healthcheck: true
 deploy_timeout: 120
 # Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
 # Remove this section when using multiple web servers and ensure you terminate SSL at your load balancer.
@@ -108,34 +110,3 @@ accessories:
     port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
-  sidekiq:
-    image: platoniq/decidim-soiltribes
-    host: 188.34.186.145
-    cmd: bundle exec sidekiq
-    env:
-      clear:
-        RAILS_SERVE_STATIC_FILES: true
-        DECIDIM_APPLICATION_NAME: "Soiltribes"
-        DECIDIM_MAILER_SENDER: no-reply@platoniq.net
-        STORAGE_PROVIDER: s3
-        DECIDIM_FORCE_SSL: false
-        RAILS_ENV: production
-        DECIDIM_ENABLE_HTML_HEADER_SNIPPETS: true
-        DECIDIM_CACHE_EXPIRATION_TIME: "10"
-      secret:
-        - RAILS_MASTER_KEY
-        - SECRET_KEY_BASE
-        - DATABASE_URL
-        - SMTP_ADDRESS
-        - SMTP_USERNAME
-        - SMTP_PASSWORD
-        - SMTP_DOMAIN
-        - SMTP_STARTTLS_AUTO
-        - POSTGRES_PASSWORD
-        - POSTGRES_USER
-        - POSTGRES_DB
-        - AWS_ACCESS_KEY_ID
-        - AWS_SECRET_ACCESS_KEY
-        - AWS_REGION
-        - AWS_BUCKET
-        - REDIS_URL

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  config.active_job.queue_adapter = :sidekiq
   # config.active_job.queue_name_prefix = "decidim_soiltribes_production"
 
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
ActiveJob had no adapter configured, so production has been running on the in-process `AsyncAdapter` — jobs execute inside Puma and are dropped on every restart or deploy. This sets it to `:sidekiq`. `config/sidekiq.yml` already defines the queues and Sidekiq reads `REDIS_URL` from the environment, so nothing else is needed.

It also moves Sidekiq from an accessory to a `servers` role. Accessories are booted once and never updated by `kamal deploy`, and this one had no image tag, so it would have pulled `:latest` and drifted from whatever web was running. A role deploys in lockstep on the same image and inherits the `env` block including `REDIS_URL`, so the duplicated env goes away.

**Needs two things alongside it, or Sidekiq still will not connect:**

- `REDIS_URL` was `redis://localhost:6379` in both environments — corrected in `kamal-deployments` on `fix/soiltribes-redis-url`
- production's `/etc/valkey/valkey.conf` has `bind 127.0.0.1`, so Valkey refuses the kamal network; needs `0.0.0.0` and a restart (host file, not in any repo)

The accessory was never booted. The `soiltribes-workers-505e634…` container on the host is an orphan from the `workers` role deleted in a596de9 (May 2025) — 737,863 restarts — and should be removed before deploying.